### PR TITLE
add instructions to prompt to focus on bullet points

### DIFF
--- a/src/agent-info/summaryPrompt.ts
+++ b/src/agent-info/summaryPrompt.ts
@@ -3,7 +3,7 @@ import template from "../customisation/template.md";
 export const returnPrompt = `
 You are a helpful assistant that creates a PR summary based on the following git diff output. 
     
-Please summarize the changes in a concise manner, focusing on the main modifications and their implications.
+Please summarize the changes in a concise manner, focusing on the main modifications and their implications, do so in a professional tone and USE BULLET POINTS.
 
 You are required to do so according to this format, please also check the correct boxes in the checklists please do not edit the format only add content:
 


### PR DESCRIPTION
# Pull Request

## 📝 Description

- Updated the instruction text in `summaryPrompt.ts` to specify that PR summaries should be written in a professional tone and use bullet points.

---

## 🔍 Type of Change

- [x] Minor update

---

## 🧪 Testing Setup

- No specific setup required as the change is textual and does not affect functionality.

---

## 📋 Front-End Checklist

- [x] UI matches Figma designs (not applicable as it's a text change)
- [x] All functionality has been tested and meets the defined acceptance criteria (textual change, no functionality affected)
- [x] Feature-flagged any non-functional UI (not applicable)

---

## 📝 Additional Notes

- This change is intended to standardize the format and tone of PR summaries, ensuring clarity and professionalism in documentation.

## 📸 Images / Recordings

- Not applicable as the changes are purely textual and do not affect the visual interface.